### PR TITLE
Fix the undistortion module in python binder

### DIFF
--- a/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
+++ b/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
@@ -23,6 +23,7 @@ bool UndistortionModule::enabled() const {
 void UndistortionModule::setImageSize(int width, int height) {
   dist_image_size_ = cv::Size(width, height);
   rect_image_size_ = cv::Size(width, height);
+  init();
 }
 
 void UndistortionModule::setNewImageSize(int width, int height) {
@@ -43,26 +44,31 @@ void UndistortionModule::setFovScale(double fov_scale) {
 void UndistortionModule::setCameraMatrix(const std::vector<double>& camera_matrix) {
   dist_camera_matrix_ = cv::Matx33d(camera_matrix.data());
   rect_camera_matrix_ = cv::Matx33d(camera_matrix.data());
+  init();
 }
 
 void UndistortionModule::setDistortionCoefficients(const std::vector<double>& coefficients) {
   dist_distortion_coeff_ = cv::Matx14d(coefficients.data());
   rect_distortion_coeff_ = cv::Matx14d(coefficients.data());
+  init();
 }
 
 void UndistortionModule::setDistortionModel(const std::string& model) {
   dist_distortion_model_ = model;
   rect_distortion_model_ = model;
+  init();
 }
 
 void UndistortionModule::setRectificationMatrix(const std::vector<double>& rectification_matrix) {
   dist_rectification_matrix_ = cv::Matx33d(rectification_matrix.data());
   rect_rectification_matrix_ = cv::Matx33d(rectification_matrix.data());
+  init();
 }
 
 void UndistortionModule::setProjectionMatrix(const std::vector<double>& projection_matrix) {
   dist_projection_matrix_ = cv::Matx34d(projection_matrix.data());
   rect_projection_matrix_ = cv::Matx34d(projection_matrix.data());
+  init();
 }
 
 //-----------------------------------------------------------------------------

--- a/raw_image_pipeline_python/src/raw_image_pipeline_python.cpp
+++ b/raw_image_pipeline_python/src/raw_image_pipeline_python.cpp
@@ -5,6 +5,7 @@
 
 #include <cvnp/cvnp.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <raw_image_pipeline/raw_image_pipeline.hpp>
 
 namespace py = pybind11;
@@ -50,11 +51,11 @@ PYBIND11_MODULE(_py_raw_image_pipeline, m) {
       .def("set_undistortion_new_image_size", &RawImagePipeline::setUndistortionNewImageSize)
       .def("set_undistortion_balance", &RawImagePipeline::setUndistortionBalance)
       .def("set_undistortion_fov_scale", &RawImagePipeline::setUndistortionFovScale)
-      .def("set_undistortion_camera_matrix", &RawImagePipeline::setUndistortionDistortionCoefficients)
-      .def("set_undistortion_distortion_coeffs", &RawImagePipeline::setUndistortionDistortionModel)
-      .def("set_undistortion_distortion_model", &RawImagePipeline::setUndistortionRectificationMatrix)
+      .def("set_undistortion_camera_matrix", &RawImagePipeline::setUndistortionCameraMatrix)
+      .def("set_undistortion_distortion_coeffs", &RawImagePipeline::setUndistortionDistortionCoefficients)
+      .def("set_undistortion_distortion_model", &RawImagePipeline::setUndistortionDistortionModel)
+      .def("set_undistortion_rectification_matrix", &RawImagePipeline::setUndistortionRectificationMatrix)
       .def("set_undistortion_projection_matrix", &RawImagePipeline::setUndistortionProjectionMatrix)
-      .def("get_dist_image_height", &RawImagePipeline::getDistImageHeight)
       .def("get_dist_image_height", &RawImagePipeline::getDistImageHeight)
       .def("get_dist_image_width", &RawImagePipeline::getDistImageWidth)
       .def("get_dist_distortion_model", &RawImagePipeline::getDistDistortionModel)
@@ -62,7 +63,6 @@ PYBIND11_MODULE(_py_raw_image_pipeline, m) {
       .def("get_dist_distortion_coefficients", &RawImagePipeline::getDistDistortionCoefficients)
       .def("get_dist_rectification_matrix", &RawImagePipeline::getDistRectificationMatrix)
       .def("get_dist_projection_matrix", &RawImagePipeline::getDistProjectionMatrix)
-      .def("get_rect_image_height", &RawImagePipeline::getRectImageHeight)
       .def("get_rect_image_height", &RawImagePipeline::getRectImageHeight)
       .def("get_rect_image_width", &RawImagePipeline::getRectImageWidth)
       .def("get_rect_distortion_model", &RawImagePipeline::getRectDistortionModel)


### PR DESCRIPTION
This pull fix the Python binder

1. fix the correspondence: `set_undistortion_camera_matrix` was envoking the wrong functions, and `set_undistortion_rectification_matrix` is missed
2. include `<pybind11/stl.h>` to fix issue when using `set_undistortion_camera_matrix` since `std::vector` is used here
3. remove duplicated `image_height`s