### PR TITLE
Fixes for realsense support

### DIFF
--- a/raw_image_pipeline/include/raw_image_pipeline/modules/debayer.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/debayer.hpp
@@ -35,9 +35,9 @@ class DebayerModule {
   //-----------------------------------------------------------------------------
   template <typename T>
   bool apply(T& image, std::string& encoding) {
-    if (!enabled_) {
-      return false;
-    }
+    // if (!enabled_) {
+    //   return false;
+    // }
     // Check encoding
     std::string input_encoding = encoding_ == "auto" ? encoding : encoding_;
     // Run debayer

--- a/raw_image_pipeline/include/raw_image_pipeline/raw_image_pipeline.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/raw_image_pipeline.hpp
@@ -134,6 +134,7 @@ class RawImagePipeline {
   cv::Mat getDistDebayeredImage() const;
   cv::Mat getDistColorImage() const;
   cv::Mat getRectMask() const;
+  cv::Mat getProcessedImage() const;
 
  private:
   //-----------------------------------------------------------------------------
@@ -165,6 +166,14 @@ class RawImagePipeline {
 
     undistorter_->apply(image);
     saveDebugImage(image, "/tmp/07_undistortion.png");
+
+    // Save processed output
+    saveOutput(image);
+  }
+
+  void saveOutput(const cv::Mat& image) {
+    // copy to internal image
+    image.copyTo(image_);
   }
 
   void saveDebugImage(const cv::Mat& image, const std::string& filename) const {
@@ -181,6 +190,11 @@ class RawImagePipeline {
     cv::Mat tmp;
     image.download(tmp);
     saveDebugImage(tmp, filename);
+  }
+
+  void saveOutput(const cv::cuda::GpuMat& image) {
+    // download to internal image
+    image.download(image_);
   }
 #endif
 
@@ -202,6 +216,9 @@ class RawImagePipeline {
   // Pipeline options
   bool use_gpu_;
   bool debug_;
+
+  // Internal variables
+  cv::Mat image_;
 };
 
 }  // namespace raw_image_pipeline

--- a/raw_image_pipeline/src/raw_image_pipeline/modules/debayer.cpp
+++ b/raw_image_pipeline/src/raw_image_pipeline/modules/debayer.cpp
@@ -48,27 +48,34 @@ void DebayerModule::debayer(cv::Mat& image, std::string& encoding) {
   if (encoding == "bayer_bggr8") {
     cv::demosaicing(image, out, cv::COLOR_BayerBG2BGR);
     image = out;
+    encoding = "bgr8";
     cv::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
+
   } else if (encoding == "bayer_gbrg8") {
     cv::demosaicing(image, out, cv::COLOR_BayerGB2BGR);
     image = out;
+    encoding = "bgr8";
     cv::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
+
   } else if (encoding == "bayer_grbg8") {
     cv::demosaicing(image, out, cv::COLOR_BayerGR2BGR);
     image = out;
+    encoding = "bgr8";
     cv::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
+
   } else if (encoding == "bayer_rggb8") {
     cv::demosaicing(image, out, cv::COLOR_BayerRG2BGR);
     image = out;
+    encoding = "bgr8";
+    cv::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
+
+  } else if (encoding == "rgb8") {
     cv::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
   }
   // We ignore non-bayer encodings
   else if (isBayerEncoding(encoding)) {
     throw std::invalid_argument("Encoding [" + encoding + "] is a valid pattern but is not supported!");
   }
-
-  // Update encoding
-  encoding = "bgr8";
 }
 
 void DebayerModule::saveDebayeredImage(cv::Mat& image) {
@@ -85,23 +92,31 @@ void DebayerModule::debayer(cv::cuda::GpuMat& image, std::string& encoding) {
   if (encoding == "bayer_bggr8") {
     cv::cuda::demosaicing(image, out, cv::cuda::COLOR_BayerBG2BGR_MHT);
     image = out;
+    encoding = "bgr8";
+
   } else if (encoding == "bayer_gbrg8") {
     cv::cuda::demosaicing(image, out, cv::cuda::COLOR_BayerGB2BGR_MHT);
     image = out;
+    encoding = "bgr8";
+
   } else if (encoding == "bayer_grbg8") {
     cv::cuda::demosaicing(image, out, cv::cuda::COLOR_BayerGR2BGR_MHT);
     image = out;
+    encoding = "bgr8";
+
   } else if (encoding == "bayer_rggb8") {
     cv::cuda::demosaicing(image, out, cv::cuda::COLOR_BayerRG2BGR_MHT);
     image = out;
+    encoding = "bgr8";
+
+  } else if (encoding == "rgb8") {
+    cv::cuda::cvtColor(image, image, cv::COLOR_RGB2BGR);  // Fix because apparently the CPU demosaicing produces RGB
+    encoding = "bgr8";
   }
   // We ignore non-bayer encodings
   else if (isBayerEncoding(encoding)) {
     throw std::invalid_argument("Encoding [" + encoding + "] is a valid pattern but is not supported!");
   }
-
-  // Update encoding
-  encoding = "bgr8";
 }
 
 void DebayerModule::saveDebayeredImage(cv::cuda::GpuMat& image) {

--- a/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
+++ b/raw_image_pipeline/src/raw_image_pipeline/modules/undistortion.cpp
@@ -233,7 +233,8 @@ void UndistortionModule::init() {
 
 void UndistortionModule::undistort(cv::Mat& image) {
   cv::Mat out;
-  cv::remap(image, out, undistortion_map_x_, undistortion_map_y_, cv::InterpolationFlags::INTER_LINEAR, cv::BorderTypes::BORDER_CONSTANT, 0);
+  cv::remap(image, out, undistortion_map_x_, undistortion_map_y_, cv::InterpolationFlags::INTER_LINEAR, cv::BorderTypes::BORDER_CONSTANT,
+            0);
   image = out;
 }
 
@@ -244,7 +245,8 @@ void UndistortionModule::saveUndistortedImage(cv::Mat& image) {
 #ifdef HAS_CUDA
 void UndistortionModule::undistort(cv::cuda::GpuMat& image) {
   cv::cuda::GpuMat out;
-  cv::cuda::remap(image, out, gpu_undistortion_map_x_, gpu_undistortion_map_y_, cv::InterpolationFlags::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
+  cv::cuda::remap(image, out, gpu_undistortion_map_x_, gpu_undistortion_map_y_, cv::InterpolationFlags::INTER_LINEAR, cv::BORDER_CONSTANT,
+                  0);
   image = out;
 }
 

--- a/raw_image_pipeline/src/raw_image_pipeline/raw_image_pipeline.cpp
+++ b/raw_image_pipeline/src/raw_image_pipeline/raw_image_pipeline.cpp
@@ -21,9 +21,9 @@ RawImagePipeline::RawImagePipeline(bool use_gpu) : use_gpu_(use_gpu), debug_(fal
 }
 
 RawImagePipeline::RawImagePipeline(bool use_gpu, const std::string& params_path, const std::string& calibration_path,
-                             const std::string& color_calibration_path)
+                                   const std::string& color_calibration_path)
     : use_gpu_(use_gpu) {
-    // Load parameters
+  // Load parameters
   if (params_path.empty())
     loadParams(DEFAULT_PARAMS_PATH);
   else
@@ -229,6 +229,10 @@ cv::Mat RawImagePipeline::getDistColorImage() const {
 
 cv::Mat RawImagePipeline::getRectMask() const {
   return undistorter_->getRectMask();
+}
+
+cv::Mat RawImagePipeline::getProcessedImage() const {
+  return image_.clone();
 }
 
 //-----------------------------------------------------------------------------

--- a/raw_image_pipeline_ros/launch/raw_image_pipeline_node.launch
+++ b/raw_image_pipeline_ros/launch/raw_image_pipeline_node.launch
@@ -30,7 +30,7 @@
   <!-- Debayer  -->
   <arg name="debayer_encoding"                     default="auto"/>  <!-- auto, bayer_bggr8, bayer_gbrg8, bayer_grbg8, bayer_rggb8-->
    <!-- Flip  -->
-  <arg name="flip/angle"                           default="0"/>  <!-- 90 (clockwise), 180, 270 (counter-clockwise) -->
+  <arg name="flip/angle"                           default="180"/>  <!-- 90 (clockwise), 180, 270 (counter-clockwise) -->
   <!-- White balance options -->
   <arg name="white_balance/method"                 default="ccc"/> <!-- simple, grey_world, learned, ccc, pca -->
   <arg name="white_balance/clipping_percentile"    default="10"/>  <!-- simple WB, values [0-100]-->


### PR DESCRIPTION
This enables options to work with depth data, as required to work with the alphasense. See https://github.com/leggedrobotics/raw_image_pipeline/issues/9