### PR TITLE
Update OpenCV CUDA includes to work with OpenCV 4.5.0 and CUDA 11.4

### DIFF
--- a/raw_image_pipeline/include/raw_image_pipeline/modules/color_calibration.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/color_calibration.hpp
@@ -11,6 +11,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <npp.h>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
@@ -66,6 +67,7 @@ class ColorCalibrationModule {
 
   void colorCorrection(cv::Mat& image);
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void colorCorrection(cv::cuda::GpuMat& image);
 #endif
 
@@ -81,6 +83,7 @@ class ColorCalibrationModule {
   cv::Scalar color_calibration_bias_;
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   Npp32f gpu_color_calibration_matrix_[3][4] = {{1.f, 0.f, 0.f, 0.f}, {0.f, 1.f, 0.f, 0.f}, {0.f, 0.f, 1.f, 0.f}};
 #endif
 };

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/color_enhancer.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/color_enhancer.hpp
@@ -8,6 +8,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #endif
@@ -48,6 +49,7 @@ class ColorEnhancerModule {
  private:
   void enhance(cv::Mat& image);
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void enhance(cv::cuda::GpuMat& image);
 #endif
 

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/debayer.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/debayer.hpp
@@ -8,6 +8,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #endif
@@ -56,6 +57,7 @@ class DebayerModule {
   void saveDebayeredImage(cv::Mat& image);
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void debayer(cv::cuda::GpuMat& image, std::string& encoding);
   void saveDebayeredImage(cv::cuda::GpuMat& image);
 #endif

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/flip.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/flip.hpp
@@ -8,6 +8,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #endif
@@ -52,6 +53,7 @@ class FlipModule {
   void saveFlippedImage(cv::Mat& image);
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void flip(cv::cuda::GpuMat& image);
   void saveFlippedImage(cv::cuda::GpuMat& image);
 #endif

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/gamma_correction.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/gamma_correction.hpp
@@ -8,6 +8,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #endif
@@ -52,6 +53,7 @@ class GammaCorrectionModule {
   // Wrapper methods (GPU)
   //-----------------------------------------------------------------------------
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void gammaCorrectCustom(cv::cuda::GpuMat& image);
   void gammaCorrectDefault(cv::cuda::GpuMat& image);
 #endif
@@ -75,6 +77,7 @@ class GammaCorrectionModule {
   cv::Mat cpu_lut_;
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   cv::Ptr<cv::cuda::LookUpTable> gpu_lut_;
 #endif
 };

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/undistortion.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/undistortion.hpp
@@ -11,6 +11,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #include <opencv2/cudawarping.hpp>
@@ -91,6 +92,7 @@ class UndistortionModule {
   void saveUndistortedImage(cv::Mat& image);
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void undistort(cv::cuda::GpuMat& image);
   void saveUndistortedImage(cv::cuda::GpuMat& image);
 #endif
@@ -127,6 +129,7 @@ class UndistortionModule {
   cv::Mat undistortion_map_y_;
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   cv::cuda::GpuMat gpu_undistortion_map_x_;
   cv::cuda::GpuMat gpu_undistortion_map_y_;
 #endif

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/vignetting_correction.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/vignetting_correction.hpp
@@ -8,6 +8,7 @@
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #endif
@@ -45,6 +46,7 @@ class VignettingCorrectionModule {
  private:
   void correct(cv::Mat& image);
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void correct(cv::cuda::GpuMat& image);
 #endif
 
@@ -60,6 +62,7 @@ class VignettingCorrectionModule {
   cv::Mat vignetting_mask_f_;
   cv::Mat image_f_;
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   cv::cuda::GpuMat gpu_vignetting_mask_f_;
   cv::cuda::GpuMat gpu_image_f_;
 #endif

--- a/raw_image_pipeline/include/raw_image_pipeline/modules/white_balance.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/modules/white_balance.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #include <opencv2/cudawarping.hpp>
@@ -98,6 +99,7 @@ class WhiteBalanceModule {
 // White balance wrapper methods (GPU)
 //-----------------------------------------------------------------------------
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void balanceWhiteSimple(cv::cuda::GpuMat& image);
   void balanceWhiteGreyWorld(cv::cuda::GpuMat& image);
   void balanceWhiteLearned(cv::cuda::GpuMat& image);

--- a/raw_image_pipeline/include/raw_image_pipeline/raw_image_pipeline.hpp
+++ b/raw_image_pipeline/include/raw_image_pipeline/raw_image_pipeline.hpp
@@ -10,6 +10,7 @@
 #include <opencv2/xphoto.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #include <opencv2/cudawarping.hpp>
@@ -177,6 +178,7 @@ class RawImagePipeline {
   }
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void saveDebugImage(const cv::cuda::GpuMat& image, const std::string& filename) const {
     cv::Mat tmp;
     image.download(tmp);

--- a/raw_image_pipeline_white_balance/include/raw_image_pipeline_white_balance/convolutional_color_constancy.hpp
+++ b/raw_image_pipeline_white_balance/include/raw_image_pipeline_white_balance/convolutional_color_constancy.hpp
@@ -23,6 +23,7 @@ inspired by Jonathan Barron's "Fast Fourier Color Constancy", CVPR, 2017
 #include <opencv2/opencv.hpp>
 
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/core/cuda.hpp>
 #include <opencv2/cudaarithm.hpp>
 #endif
@@ -47,6 +48,7 @@ class ConvolutionalColorConstancyWB {
 
   Model<cv::Mat> model_;
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   Model<cv::cuda::GpuMat> gpu_model_;
 #endif
 
@@ -106,6 +108,7 @@ class ConvolutionalColorConstancyWB {
 
 // Compute and apply RGB gains
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   int computeResponseCuda();
   void applyGainsCuda(cv::cuda::GpuMat& image);
 #endif
@@ -117,6 +120,7 @@ class ConvolutionalColorConstancyWB {
 
 // Applies white balance
 #ifdef HAS_CUDA
+#include <opencv2/cudaarithm.hpp>
   void balanceWhite(const cv::cuda::GpuMat& src, cv::cuda::GpuMat& dst);
 #endif
   void balanceWhite(const cv::Mat& src, cv::Mat& dst);


### PR DESCRIPTION
These are the headers I had to include to get raw_image_pipeline working on a Jetson Orin with OpenCV 4.5.0 and CUDA 11.4. I have not tested if they are backwards compatible with OpenCV 4.2.0 and CUDA 10.2.