### PR TITLE
Fix color image publisher logic when undistortion is enabled

### DIFF
--- a/raw_image_pipeline_ros/src/raw_image_pipeline_ros.cpp
+++ b/raw_image_pipeline_ros/src/raw_image_pipeline_ros.cpp
@@ -252,7 +252,7 @@ void RawImagePipelineRos::imageCallback(const sensor_msgs::ImageConstPtr& image_
     );
   }
 
-  if (input_type_ == "color") {
+  if (input_type_ == "color" && raw_image_pipeline_->isDebayerEnabled()) {
     // Publish debayered image
     cv_ptr_processed->image = raw_image_pipeline_->getDistDebayeredImage();
     publishColorImage(cv_ptr_processed,                                                                     // Processed
@@ -268,9 +268,12 @@ void RawImagePipelineRos::imageCallback(const sensor_msgs::ImageConstPtr& image_
     );
   }
 
-  // Publish default image
-  // cv_ptr_processed->image = raw_image_pipeline_->getDistColorImage();
-  cv_ptr_processed->image = raw_image_pipeline_->getProcessedImage();
+  // Publish color image
+  if (raw_image_pipeline_->isUndistortionEnabled()) {
+    cv_ptr_processed->image = raw_image_pipeline_->getDistColorImage();
+  } else {
+    cv_ptr_processed->image = raw_image_pipeline_->getProcessedImage();
+  }
   publishColorImage(cv_ptr_processed,                                                                     // Processed
                     image_msg,                                                                            // Original image
                     cv::Mat(),                                                                            // Mask


### PR DESCRIPTION
This fixes the bug that published undistorted iamges in the color topic when undistortion was enabled.
The correct behavior is that the `/camera/color/image` topic should have the distorted color-corrected image, while `/camera/color_rect/image` should have the undistorted one. 

This makes the camera_info topics `/camera/color/camera_info` and `/camera/color_rect/camera_info` consistent now.